### PR TITLE
be more verbose when building sysconftool

### DIFF
--- a/build_sysconftool.sh
+++ b/build_sysconftool.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 set -e
 
+srpm="sysconftool-0.17-1.fc20.src.rpm"
+
 cd /tmp/
-curl -L -O http://fedora.mirror.lstn.net//releases/20/Everything/source/SRPMS/s/sysconftool-0.17-1.fc20.src.rpm
-rpm -Uvh sysconftool-*.rpm
-yum-builddep -y /rpmbuild/SPECS/sysconftool.spec
-rpmbuild -ba /rpmbuild/SPECS/sysconftool.spec
-yum -y localinstall /rpmbuild/RPMS/noarch/sysconftool-*.rpm
+curl -L -O http://fedora.mirror.lstn.net/releases/20/Everything/source/SRPMS/s/$srpm
+rpm -Uvh /tmp/$srpm
+
+spec=$(find / -name sysconftool.spec)
+echo "spec: $spec"
+yum-builddep -y $spec
+rpmbuild -ba $spec
+
+rpms="$(find / -regex '.*sysconftool.*noarch.rpm')"
+echo "rpms: $rpms"
+yum -y localinstall $rpms


### PR DESCRIPTION
Oddly, everything worked fine (before this commit) on my coreos host.
But on wercker host, the build failed with:

```
error: Unable to open /rpmbuild/SPECS/sysconftool.spec: No such file or directory
Bad spec: /rpmbuild/SPECS/sysconftool.spec
No uninstalled build requires
error: failed to stat /rpmbuild/SPECS/sysconftool.spec: No such file or directory
2014/09/07 16:24:39 The command [/bin/sh -c /tmp/build_sysconftool.sh] returned a non-zero code: 1
```
